### PR TITLE
Reworked UI generation in QML

### DIFF
--- a/configurator/ConfigSchemaHelper.cpp
+++ b/configurator/ConfigSchemaHelper.cpp
@@ -236,7 +236,9 @@ const char* CConfigSchemaHelper::printQML(const char* comp, int nIdx) const
              if (pSchema != NULL)
              {
                  //pSchema->loadXMLFromEnvXml(CConfigSchemaHelper::getConstEnvPropertyTree());
-                 pSchema->getQML2(strQML, nIdx);
+                 //pSchema->getQML2(strQML, nIdx);
+                 pSchema->getQML3(strQML, nIdx);
+
                  return strQML.str();
              }
         }
@@ -728,7 +730,7 @@ const char* CConfigSchemaHelper::getTableValue(const char* pXPath,  int nRow) co
             char pTemp[64];
             int offset = strlen(itoa(nRow, pTemp, 10)) - 1;
 
-            strXPath.append((String(strXPathOrignal).substring(strXPath.length()-offset, strXPathOrignal.length()))->str());
+            strXPath.append((String(strXPathOrignal).substring(strXPath.length()-offset, strXPathOrignal.length())));
             //strXPath.append((String(strXPathOrignal).substring(strXPath.length()-offset, strXPathOrignal.length()))->toCharArray());
 
             pAttribute = m_pSchemaMapManager->getAttributeFromXPath(strXPath.str());

--- a/configurator/ConfigSchemaHelper.cpp
+++ b/configurator/ConfigSchemaHelper.cpp
@@ -235,10 +235,7 @@ const char* CConfigSchemaHelper::printQML(const char* comp, int nIdx) const
 
              if (pSchema != NULL)
              {
-                 //pSchema->loadXMLFromEnvXml(CConfigSchemaHelper::getConstEnvPropertyTree());
-                 //pSchema->getQML2(strQML, nIdx);
                  pSchema->getQML3(strQML, nIdx);
-
                  return strQML.str();
              }
         }
@@ -723,15 +720,13 @@ const char* CConfigSchemaHelper::getTableValue(const char* pXPath,  int nRow) co
             StringBuffer strXPathOrignal(pXPath);
 
             CConfigSchemaHelper::stripXPathIndex(strXPath);
-            CConfigSchemaHelper::stripXPathIndex(strXPath);
 
             strXPath.appendf("[%d]", nRow);
 
             char pTemp[64];
-            int offset = strlen(itoa(nRow, pTemp, 10)) - 1;
+            int offset = strXPath.length() - (strlen(itoa(nRow, pTemp, 10)) - 1);
 
-            strXPath.append((String(strXPathOrignal).substring(strXPath.length()-offset, strXPathOrignal.length())));
-            //strXPath.append((String(strXPathOrignal).substring(strXPath.length()-offset, strXPathOrignal.length()))->toCharArray());
+            strXPath.append(strXPathOrignal, strXPath.length(), strXPathOrignal.length()-offset);
 
             pAttribute = m_pSchemaMapManager->getAttributeFromXPath(strXPath.str());
 

--- a/configurator/ConfiguratorAPI.cpp
+++ b/configurator/ConfiguratorAPI.cpp
@@ -122,15 +122,16 @@ int initialize(int argc, char *argv[])
 
 int getValue(const char *pXPath, char *pValue)
 {
-    int counter = 0;
-    itoa(counter, pValue, 10);
-    counter++;
-
+    // By Default, return xPath as value.
+    strcpy(pValue, pXPath);
     CAttribute *pAttribute = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getAttributeFromXPath(pXPath);
 
-    assert(pAttribute != NULL);
-
-    if (pAttribute->isInstanceValueValid() == true)
+    //assert(pAttribute != NULL);
+    if(pAttribute == NULL)
+    {
+        std::cout << pXPath << " is an Invalid xPath, returning xPath as value" << std::endl;
+    }
+    else if (pAttribute->isInstanceValueValid() == true)
     {
         //strcpy(pValue, pAttribute->getEnvValueFromXML());
         strcpy(pValue, pAttribute->getInstanceValue());
@@ -226,7 +227,7 @@ const char* getTableValue(const char *pXPath, int nRow)
             //int offset = strlen(itoa(nRow, pTemp, 10)) - 1;
 
             //strXPath.append((String(strXPathOrignal).substring(strXPath.length()-offset, strXPathOrignal.length()))->toCharArray());
-            strXPath.append((String(strXPathOrignal).substring(strXPathOrignal.length()-offset-1, strXPathOrignal.length()))->str());
+            strXPath.append((String(strXPathOrignal).substring(strXPathOrignal.length()-offset-1, strXPathOrignal.length())));
 
             pAttribute =  CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getAttributeFromXPath(strXPath.str());
 

--- a/configurator/ConfiguratorAPI.cpp
+++ b/configurator/ConfiguratorAPI.cpp
@@ -217,19 +217,15 @@ const char* getTableValue(const char *pXPath, int nRow)
         else
         {
             StringBuffer strXPath(pXPath);
-            const StringBuffer strXPathOrignal(pXPath);
+            const StringBuffer strXPathOriginal(pXPath);
 
 
-            int offset = CConfigSchemaHelper::stripXPathIndex(strXPath);
+            int offset = strXPathOriginal.length() - (CConfigSchemaHelper::stripXPathIndex(strXPath) + 1) ;
             CConfigSchemaHelper::stripXPathIndex(strXPath);
 
             strXPath.appendf("[%d]", nRow);
 
-            //char pTemp[64];
-            //int offset = strlen(itoa(nRow, pTemp, 10)) - 1;
-
-            //strXPath.append((String(strXPathOrignal).substring(strXPath.length()-offset, strXPathOrignal.length()))->toCharArray());
-            strXPath.append((String(strXPathOrignal).substring(strXPathOrignal.length()-offset-1, strXPathOrignal.length())));
+            strXPath.append(strXPathOriginal, offset, strXPathOriginal.length() - offset);
 
             pAttribute =  CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getAttributeFromXPath(strXPath.str());
 

--- a/configurator/ConfiguratorAPI.cpp
+++ b/configurator/ConfiguratorAPI.cpp
@@ -129,17 +129,19 @@ int getValue(const char *pXPath, char *pValue)
     //assert(pAttribute != NULL);
     if(pAttribute == NULL)
     {
-        std::cout << pXPath << " is an Invalid xPath, returning xPath as value" << std::endl;
+        std::cout << "xPath: " << pXPath << "| value: " << pXPath << std::endl;
     }
     else if (pAttribute->isInstanceValueValid() == true)
     {
         //strcpy(pValue, pAttribute->getEnvValueFromXML());
         strcpy(pValue, pAttribute->getInstanceValue());
+        std::cout << "xPath: " << pXPath << "| value: " << pValue << std::endl;
     }
-    else
-    {
+    /*else
+    { // If attribute is valid but instance does not exist
+        std::cout << "xPath: " << pXPath << "| value: NULL" << std::endl;
         pValue = NULL;
-    }
+    }*/
     return true;
 }
 

--- a/configurator/QMLMarkup.cpp
+++ b/configurator/QMLMarkup.cpp
@@ -2,6 +2,7 @@
 #include "SchemaCommon.hpp"
 #include "jstring.hpp"
 #include "jutil.hpp"
+#include "jarray.hpp"
 #include "jdebug.hpp"
 #include "SchemaAttributes.hpp"
 #include "SchemaElement.hpp"
@@ -9,6 +10,7 @@
 #include "SchemaAnnotation.hpp"
 
 int CQMLMarkupHelper::glImplicitHeight = -1;
+
 
 void CQMLMarkupHelper::getTabQML(StringBuffer &strQML, const char *pName)
 {
@@ -157,4 +159,53 @@ bool CQMLMarkupHelper::isTableRequired(const CAttribute *pAttrib)
     {
         return false;
     }
+}
+
+void CQMLMarkupHelper::buildAccordionStart(StringBuffer &strQML, const char * title, const char * altTitle, int idx)
+{
+    assert(title != NULL);
+    strQML.append("AccordionItem {\n\
+                            title: \"").append(title).append("\"\n");
+    if(strlen(altTitle)){
+        strQML.append("altTitle: \"").append(altTitle).append("\"\n");
+    }
+    strQML.append("index: ").append(idx).append("\n\
+                            contentModel: VisualItemModel {\n");
+}
+void CQMLMarkupHelper::buildColumns(StringBuffer &strQML, StructArrayOf<StringBuffer> &roles, StructArrayOf<StringBuffer> &titles)
+{  
+    /*
+    Sample QML for Column Instance
+    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
+     */
+    assert(roles.length() == titles.length());
+    strQML.append("columnNames: [");
+    for(int i = 0; i < roles.length(); i++){
+        strQML.append("{ role:\"").append(roles[i]).append("\", title:\"").append(titles[i]).append("\" }");
+        if(i != roles.length() - 1)
+            strQML.append(",");
+    }
+    strQML.append("]\n");
+}
+
+void CQMLMarkupHelper::buildRole(StringBuffer &strQML, const char * role, StructArrayOf<StringBuffer> &values, const char * type, const char * tooltip, const char * placeholder)
+{
+    StringBuffer escapedToolTip = tooltip;
+    escapedToolTip.replaceString("\"","\\\"");
+    StringBuffer escapedPlaceholder = placeholder;
+    escapedPlaceholder.replaceString("\"","\\\"");
+    strQML.append(role);
+    strQML.append(": ListElement { \n");
+    strQML.append("value:[");
+    for(int i = 0; i < values.length(); i++){
+        strQML.append("ListElement {value: \"");
+        strQML.append(values[i]);
+        strQML.append("\"}");
+        if(i != values.length()-1)
+            strQML.append(",");
+    }
+    strQML.append("]\n");
+    strQML.append("type: \"").append(type).append("\"\n");
+    strQML.append("tooltip: \"").append(escapedToolTip).append("\"\n");
+    strQML.append("placeholder: \"").append(escapedPlaceholder).append("\"}\n");
 }

--- a/configurator/QMLMarkup.cpp
+++ b/configurator/QMLMarkup.cpp
@@ -11,7 +11,6 @@
 
 int CQMLMarkupHelper::glImplicitHeight = -1;
 
-
 void CQMLMarkupHelper::getTabQML(StringBuffer &strQML, const char *pName)
 {
     assert(pName != NULL);
@@ -163,49 +162,71 @@ bool CQMLMarkupHelper::isTableRequired(const CAttribute *pAttrib)
 
 void CQMLMarkupHelper::buildAccordionStart(StringBuffer &strQML, const char * title, const char * altTitle, int idx)
 {
+    StringBuffer result;
     assert(title != NULL);
-    strQML.append("AccordionItem {\n\
-                            title: \"").append(title).append("\"\n");
+    result.append("AccordionItem {\n");
+    result.append(CQMLMarkupHelper::printProperty("title",title));
     if(strlen(altTitle)){
-        strQML.append("altTitle: \"").append(altTitle).append("\"\n");
+        result.append(CQMLMarkupHelper::printProperty("altTitle",altTitle));
     }
-    strQML.append("index: ").append(idx).append("\n\
-                            contentModel: VisualItemModel {\n");
+    char * index = NULL;
+    /*numtostr(index,idx);
+    result.append(CQMLMarkupHelper::printProperty("index",index));*/
+    result.append("contentModel: VisualItemModel {\n");
+
+    strQML.append(result);
 }
-void CQMLMarkupHelper::buildColumns(StringBuffer &strQML, StructArrayOf<StringBuffer> &roles, StructArrayOf<StringBuffer> &titles)
+void CQMLMarkupHelper::buildColumns(StringBuffer &strQML, StringArray &roles, StringArray &titles)
 {  
     /*
     Sample QML for Column Instance
     columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
      */
+    StringBuffer result;
     assert(roles.length() == titles.length());
-    strQML.append("columnNames: [");
+    result.append("columnNames: [");
     for(int i = 0; i < roles.length(); i++){
-        strQML.append("{ role:\"").append(roles[i]).append("\", title:\"").append(titles[i]).append("\" }");
+        const StringBuffer temprole = CQMLMarkupHelper::printProperty("role", roles[i], false);
+        const StringBuffer temptitle = CQMLMarkupHelper::printProperty("title", titles[i], false);
+        result.appendf("{%s,%s}", temprole.toCharArray(), temptitle.toCharArray());
         if(i != roles.length() - 1)
-            strQML.append(",");
+            result.append(",");
     }
-    strQML.append("]\n");
+    result.append("]\n");
+
+    strQML.append(result);
 }
 
-void CQMLMarkupHelper::buildRole(StringBuffer &strQML, const char * role, StructArrayOf<StringBuffer> &values, const char * type, const char * tooltip, const char * placeholder)
+void CQMLMarkupHelper::buildRole(StringBuffer &strQML, const char * role, StringArray &values, const char * type, const char * tooltip, const char * placeholder)
 {
+    StringBuffer result;
     StringBuffer escapedToolTip = tooltip;
     escapedToolTip.replaceString("\"","\\\"");
     StringBuffer escapedPlaceholder = placeholder;
     escapedPlaceholder.replaceString("\"","\\\"");
-    strQML.append(role);
-    strQML.append(": ListElement { \n");
-    strQML.append("value:[");
-    for(int i = 0; i < values.length(); i++){
-        strQML.append("ListElement {value: \"");
-        strQML.append(values[i]);
-        strQML.append("\"}");
+    result.append(role);
+    result.append(": ListElement { \n");
+    result.append("value:[");
+    for(int i = 0; i < values.length(); i++)
+{        result.append("ListElement {value: \"");
+        result.append(values[i]);
+        result.append("\"}");
         if(i != values.length()-1)
-            strQML.append(",");
+            result.append(",");
     }
-    strQML.append("]\n");
-    strQML.append("type: \"").append(type).append("\"\n");
-    strQML.append("tooltip: \"").append(escapedToolTip).append("\"\n");
-    strQML.append("placeholder: \"").append(escapedPlaceholder).append("\"}\n");
+    result.append("]\n");
+    result.append(CQMLMarkupHelper::printProperty("type",type));
+    result.append(CQMLMarkupHelper::printProperty("tooltip",escapedToolTip));
+    result.append(CQMLMarkupHelper::printProperty("placeholder",escapedPlaceholder));
+    result.append("}");
+    strQML.append(result);
+}
+
+const StringBuffer CQMLMarkupHelper::printProperty(const char * property, const char * value, const bool newline)
+{
+    StringBuffer result;
+    result.appendf("%s: \"%s\"",property,value);
+    if(newline)
+        result.append("\n");
+    return result;
 }

--- a/configurator/QMLMarkup.hpp
+++ b/configurator/QMLMarkup.hpp
@@ -4,8 +4,8 @@
 //#include "jarray.hpp"
 class StringBuffer;
 class CAttribute;
-template <typename CLASS>
-class StructArrayOf;
+class StringArray;
+class String;
    
 
 static const char* QML_TABLE_DATA_MODEL(" tableDataModel\n");
@@ -520,11 +520,13 @@ class CQMLMarkupHelper
 {
 public:
     // New Helper Functions
-    static void buildAccordionStart(StringBuffer &strQML, const char * title, const char * altTitle = "", int idx = -5);
+    static void buildAccordionStart(StringBuffer &strQML, const char * title, const char * altTitle = "", int idx = -1);
     // End Accordion with QML_DOUBLE_END_BRACKET
 
-    static void buildColumns(StringBuffer &strQML, StructArrayOf<StringBuffer> &roles, StructArrayOf<StringBuffer> &titles);
-    static void buildRole(StringBuffer &strQML, const char * role, StructArrayOf<StringBuffer> &values, const char * type = "text", const char * tooltip = "", const char * placeholder = "");
+    static void buildColumns(StringBuffer &strQML, StringArray &roles, StringArray &titles);
+    static void buildRole(StringBuffer &strQML, const char * role, StringArray &values, const char * type = "text", const char * tooltip = "", const char * placeholder = "");
+
+    static const StringBuffer printProperty(const char * property, const char * value, const bool newline = true);
     // NewHelperFunctions end;
 
     static void getTabQML(StringBuffer &strQML, const char *pName);

--- a/configurator/QMLMarkup.hpp
+++ b/configurator/QMLMarkup.hpp
@@ -1,8 +1,12 @@
 #ifndef _QMLMARKUP_HPP_
 #define _QMLMARKUP_HPP_
 
+//#include "jarray.hpp"
 class StringBuffer;
 class CAttribute;
+template <typename CLASS>
+class StructArrayOf;
+   
 
 static const char* QML_TABLE_DATA_MODEL(" tableDataModel\n");
 static const char* QML_PROPERTY_STRING_TABLE_BEGIN("\
@@ -467,9 +471,62 @@ static const char* QML_TABLE_VIEW_COLUMN_TITLE_BEGIN("\
 
 static const char* QML_TABLE_VIEW_COLUMN_TITLE_END("\"\n");
 
+// New Constants
+static const char* QML_FILE_START("\
+import QtQuick 2.1                                  \n\
+import QtQuick.Controls 1.2                         \n\
+import QtQuick.Controls.Styles 1.0                  \n\
+import QtQuick.Particles 2.0                        \n\
+import QtQuick.Layouts 1.0                          \n\
+Item {                                              \n\
+    id: gRoot                                       \n\
+    width: 900                                      \n\
+    height: 700                                     \n\
+    property alias root: gRoot                      \n\
+    ScrollView{                                     \n\
+        id: scrollRoot                              \n\
+        anchors.fill: parent                        \n\
+        ListView{                                   \n\
+            id: listRoot                            \n\
+            property int nest: 0                    \n\
+            property int visibility: 0              \n\
+            anchors.fill: parent                    \n\
+            spacing: 4                              \n\
+            model: configModel                      \n\
+            opacity: !visibility                    \n\
+            transitions: Transition {               \n\
+                NumberAnimation {                   \n\
+                    properties: 'opacity'           \n\
+                    easing.type: Easing.InOutQuad   \n\
+                    duration: 1000                  \n\
+                }                                   \n\
+            }                                       \n\
+        }                                           \n\
+    }                                               \n\
+    VisualItemModel {                               \n\
+        id: configModel");
+static const char * QML_DOUBLE_END_BRACKET("}\n}\n");
+// Always start content before column
+static const char * QML_TABLE_START("Table{                 \n");
+static const char * QML_TABLE_CONTENT_START("tableContent: ListModel {                      \n");
+static const char * QML_TABLE_ROW_START("ListElement {");
+static const char * QML_TABLE_ROW_END("}\n");
+static const char * QML_TABLE_CONTENT_END("}\n");
+static const char * QML_TABLE_END("}\n");
+// Table ends can be replaced with DOUBLE_END_BRACKET in appropriate situations (if buildColumns are done before Content)
+
+// NewConstants end;
 class CQMLMarkupHelper
 {
 public:
+    // New Helper Functions
+    static void buildAccordionStart(StringBuffer &strQML, const char * title, const char * altTitle = "", int idx = -5);
+    // End Accordion with QML_DOUBLE_END_BRACKET
+
+    static void buildColumns(StringBuffer &strQML, StructArrayOf<StringBuffer> &roles, StructArrayOf<StringBuffer> &titles);
+    static void buildRole(StringBuffer &strQML, const char * role, StructArrayOf<StringBuffer> &values, const char * type = "text", const char * tooltip = "", const char * placeholder = "");
+    // NewHelperFunctions end;
+
     static void getTabQML(StringBuffer &strQML, const char *pName);
 
     static void getComboBoxListElement(const char* pLabel, StringBuffer &strID, const char* pDefault = "");

--- a/configurator/SchemaAttributeGroup.cpp
+++ b/configurator/SchemaAttributeGroup.cpp
@@ -1,4 +1,4 @@
-﻿#include "SchemaAttributeGroup.hpp"
+#include "SchemaAttributeGroup.hpp"
 #include "DocumentationMarkup.hpp"
 #include "ConfigSchemaHelper.hpp"
 #include "jptree.hpp"
@@ -120,16 +120,13 @@ void CAttributeGroup::getQML(StringBuffer &strQML, int idx) const
 void CAttributeGroup::getQML3(StringBuffer &strQML, int idx) const
 {
     DEBUG_MARK_QML;
-    if (this->getRef() != NULL && this->getRef()[0] != 0 && m_pRefAttributeGroup != NULL)
+    if (this->getRef() != NULL && this->getRef()[0] != 0 && m_pRefAttributeGroup != NULL && m_pRefAttributeGroup->getConstAttributeArray() != NULL)
     {
-        if (m_pRefAttributeGroup->getConstAttributeArray() != NULL)
-        {
-            DEBUG_MARK_QML;
-            CQMLMarkupHelper::buildAccordionStart(strQML, this->getRef(), "");
-            m_pRefAttributeGroup->getConstAttributeArray()->getQML3(strQML);
-            strQML.append(QML_DOUBLE_END_BRACKET);
-            DEBUG_MARK_QML;
-        }
+        DEBUG_MARK_QML;
+        CQMLMarkupHelper::buildAccordionStart(strQML, this->getRef(), "");
+        m_pRefAttributeGroup->getConstAttributeArray()->getQML3(strQML);
+        strQML.append(QML_DOUBLE_END_BRACKET);
+        DEBUG_MARK_QML;
     }
     DEBUG_MARK_QML;
 }
@@ -399,12 +396,12 @@ void CAttributeGroupArray::getQML2(StringBuffer &strQML, int idx) const
 
 void CAttributeGroupArray::getQML3(StringBuffer &strQML, int idx) const
 {
+    DEBUG_MARK_QML;
     for (int idx=0; idx < this->length(); idx++)
     {
-        DEBUG_MARK_QML;
         (this->item(idx)).getQML3(strQML);
-        DEBUG_MARK_QML;
     }
+    DEBUG_MARK_QML;
 }
 
 void CAttributeGroupArray::populateEnvXPath(StringBuffer strXPath, unsigned int index)

--- a/configurator/SchemaAttributeGroup.cpp
+++ b/configurator/SchemaAttributeGroup.cpp
@@ -3,6 +3,7 @@
 #include "ConfigSchemaHelper.hpp"
 #include "jptree.hpp"
 #include "SchemaMapManager.hpp"
+#include "QMLMarkup.hpp"
 
 const CXSDNodeBase* CAttributeGroup::getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName) const
 {
@@ -114,6 +115,23 @@ void CAttributeGroup::getQML(StringBuffer &strQML, int idx) const
             m_pRefAttributeGroup->getConstAttributeArray()->getQML(strQML);
         }
     }
+}
+
+void CAttributeGroup::getQML3(StringBuffer &strQML, int idx) const
+{
+    DEBUG_MARK_QML;
+    if (this->getRef() != NULL && this->getRef()[0] != 0 && m_pRefAttributeGroup != NULL)
+    {
+        if (m_pRefAttributeGroup->getConstAttributeArray() != NULL)
+        {
+            DEBUG_MARK_QML;
+            CQMLMarkupHelper::buildAccordionStart(strQML, this->getRef(), "");
+            m_pRefAttributeGroup->getConstAttributeArray()->getQML3(strQML);
+            strQML.append(QML_DOUBLE_END_BRACKET);
+            DEBUG_MARK_QML;
+        }
+    }
+    DEBUG_MARK_QML;
 }
 
 void CAttributeGroup::populateEnvXPath(StringBuffer strXPath, unsigned int index)
@@ -376,6 +394,16 @@ void CAttributeGroupArray::getQML2(StringBuffer &strQML, int idx) const
     for (int idx=0; idx < this->length(); idx++)
     {
         (this->item(idx)).getQML2(strQML);
+    }
+}
+
+void CAttributeGroupArray::getQML3(StringBuffer &strQML, int idx) const
+{
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        DEBUG_MARK_QML;
+        (this->item(idx)).getQML3(strQML);
+        DEBUG_MARK_QML;
     }
 }
 

--- a/configurator/SchemaAttributeGroup.hpp
+++ b/configurator/SchemaAttributeGroup.hpp
@@ -53,6 +53,7 @@ public:
     virtual void getDojoJS(StringBuffer &strJS) const;
 
     virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
 
     virtual CAnnotation* getAnnotation() const
     {
@@ -112,6 +113,7 @@ public:
 
     virtual void getQML(StringBuffer &strQML, int idx = -1) const;
     virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
 
     virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
 

--- a/configurator/SchemaAttributes.cpp
+++ b/configurator/SchemaAttributes.cpp
@@ -22,13 +22,12 @@ CAttribute::~CAttribute()
     //CConfigSchemaHelper::getInstance()->getSchemaMapManager()->removeMapOfXPathToAttribute(this->getEnvXPath());
 }
 
-bool CAttribute::isHidden(){
-    if(this->getAnnotation()->getAppInfo() != NULL){
-        if(!stricmp(this->getAnnotation()->getAppInfo()->getViewType(),"hidden")){
-            return true;
-        }
+bool CAttribute::isHidden()
+{
+    if(this->getAnnotation()->getAppInfo() != NULL && !stricmp(this->getAnnotation()->getAppInfo()->getViewType(),"hidden"))
+    {
+        return true;
     }
-    
     return false;
 }
 
@@ -447,19 +446,22 @@ void CAttribute::getQML3(StringBuffer &strQML, const char * role, int idx) const
         }
      */
     DEBUG_MARK_QML;
-    StringBuffer name(role == NULL ? this->getName() : role);
-    StructArrayOf<StringBuffer> values;
+    StringBuffer name(role == NULL || role[0] == '\0' ? this->getName() : role);
+    StringArray values;
     values.append(this->getEnvXPath());
-    if(this->getAnnotation()->getAppInfo() != NULL){
+    if(this->getAnnotation()->getAppInfo() != NULL)
+    {
         const char * viewType = this->getAnnotation()->getAppInfo()->getViewType();
-        if( viewType != NULL){
+        if( viewType != NULL)
+        {
             if(!stricmp(viewType,"readonly"))
                 viewType = "text";
             else
                 viewType = "field";
         } else viewType = "field";
         CQMLMarkupHelper::buildRole(strQML, name, values, viewType, this->getAnnotation()->getAppInfo()->getToolTip(), this->getDefault());
-    } else {
+    } else
+    {
         CQMLMarkupHelper::buildRole(strQML, name, values, "field");
     }
     DEBUG_MARK_QML
@@ -1250,16 +1252,20 @@ void CAttributeArray::getQML3(StringBuffer &strQML, int idx) const
      */
     DEBUG_MARK_QML;
     // If UI is LIST, each AttributeArray.getQML3() call needs to effectively return a row
-    if(this->getUIType() == QML_UI_TABLE_LIST){
+    if(this->getUIType() == QML_UI_TABLE_LIST)
+    {
         strQML.append(QML_TABLE_ROW_START);
-        for(int i = 0; i < this->length(); i++){
+        for(int i = 0; i < this->length(); i++)
+        {
             (this->item(i)).getQML3(strQML);
         }
         strQML.append(QML_TABLE_ROW_END);
     // Otherwise, assume Key/Val and generate your own table
-    } else {
-        StructArrayOf<StringBuffer> roles;
-        StructArrayOf<StringBuffer> titles;
+    } 
+    else 
+    {
+        StringArray roles;
+        StringArray titles;
         strQML.append(QML_TABLE_START);
         
         // Builds Columns
@@ -1272,9 +1278,10 @@ void CAttributeArray::getQML3(StringBuffer &strQML, int idx) const
         // build Rows
         for (int i = 0; i < this->length(); i++)
         {
-            if((this->item(i)).isHidden()) continue;
+            if((this->item(i)).isHidden()) 
+                continue;
             strQML.append(QML_TABLE_ROW_START);
-            StructArrayOf<StringBuffer> key;
+            StringArray key;
             key.append(this->item(i).getTitle());
             CQMLMarkupHelper::buildRole(strQML, "key", key);
             (this->item(i)).getQML3(strQML, "value");
@@ -1352,9 +1359,12 @@ const CAttribute* CAttributeArray::findAttributeWithName(const char *pName, bool
 
     return NULL;
 }
-const void CAttributeArray::getAttributeNames(StructArrayOf<StringBuffer> &names, StructArrayOf<StringBuffer> &titles) const{
-    for(int i = 0; i < this->length(); i++){
-        if(!this->item(i).isHidden()){
+const void CAttributeArray::getAttributeNames(StringArray &names, StringArray &titles) const
+{
+    for(int i = 0; i < this->length(); i++)
+    {
+        if(!this->item(i).isHidden())
+        {
             names.append(this->item(i).getName());
             titles.append(this->item(i).getTitle());
         }

--- a/configurator/SchemaAttributes.cpp
+++ b/configurator/SchemaAttributes.cpp
@@ -451,9 +451,16 @@ void CAttribute::getQML3(StringBuffer &strQML, const char * role, int idx) const
     StructArrayOf<StringBuffer> values;
     values.append(this->getEnvXPath());
     if(this->getAnnotation()->getAppInfo() != NULL){
-        CQMLMarkupHelper::buildRole(strQML, name, values, this->getAnnotation()->getAppInfo()->getViewType(),this->getAnnotation()->getAppInfo()->getToolTip(),this->getDefault());
+        const char * viewType = this->getAnnotation()->getAppInfo()->getViewType();
+        if( viewType != NULL){
+            if(!stricmp(viewType,"readonly"))
+                viewType = "text";
+            else
+                viewType = "field";
+        } else viewType = "field";
+        CQMLMarkupHelper::buildRole(strQML, name, values, viewType, this->getAnnotation()->getAppInfo()->getToolTip(), this->getDefault());
     } else {
-        CQMLMarkupHelper::buildRole(strQML, name, values);
+        CQMLMarkupHelper::buildRole(strQML, name, values, "field");
     }
     DEBUG_MARK_QML
 }

--- a/configurator/SchemaAttributes.hpp
+++ b/configurator/SchemaAttributes.hpp
@@ -1,7 +1,7 @@
 #ifndef _SCHEMA_ATTRIBUTES_HPP_
 #define _SCHEMA_ATTRIBUTES_HPP_
 
-#include "jhash.hpp"
+#include "jarray.hpp"
 #include "jatomic.hpp"
 #include "XMLTags.h"
 #include "SchemaCommon.hpp"
@@ -51,6 +51,7 @@ public:
 
     virtual void getQML(StringBuffer &strQML, int idx = -1) const;
     virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, const char * role = NULL, int idx = -1) const;
 
     virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
 
@@ -62,6 +63,8 @@ public:
     {
         return m_bInstanceValueValid;
     }
+
+    bool isHidden();
 
     virtual void setEnvValueFromXML(const char *p);
 
@@ -139,6 +142,7 @@ public:
 
     virtual void getQML(StringBuffer &strQML, int idx = -1) const;
     virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
 
     virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
 
@@ -147,6 +151,7 @@ public:
     virtual const char* getXML(const char* /*pComponent*/);
 
     const CAttribute* findAttributeWithName(const char *pName, bool bCaseInsensitive = true) const;
+    const void getAttributeNames(StructArrayOf<StringBuffer> &names, StructArrayOf<StringBuffer> &titles) const;
 
     static CAttributeArray* load(const char* pSchemaFile);
     static CAttributeArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);

--- a/configurator/SchemaAttributes.hpp
+++ b/configurator/SchemaAttributes.hpp
@@ -151,7 +151,7 @@ public:
     virtual const char* getXML(const char* /*pComponent*/);
 
     const CAttribute* findAttributeWithName(const char *pName, bool bCaseInsensitive = true) const;
-    const void getAttributeNames(StructArrayOf<StringBuffer> &names, StructArrayOf<StringBuffer> &titles) const;
+    const void getAttributeNames(StringArray &names, StringArray &titles) const;
 
     static CAttributeArray* load(const char* pSchemaFile);
     static CAttributeArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);

--- a/configurator/SchemaCommon.hpp
+++ b/configurator/SchemaCommon.hpp
@@ -175,7 +175,10 @@ enum QML_UI_TYPE
     QML_UI_TAB,
     QML_UI_TAB_CONTENTS,
     QML_UI_LABEL,
-    QML_UI_EMPTY
+    QML_UI_EMPTY,
+
+    QML_UI_TABLE_LIST,
+    QML_UI_TABLE_KEYVAL
 };
 
 static const char* DEFAULT_SCHEMA_DIRECTORY("/opt/HPCCSystems/componentfiles/configxml/");
@@ -499,6 +502,10 @@ public:
     {
     }
 
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const
+    {
+    }
+
     virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1)
     {
     }
@@ -514,7 +521,7 @@ public:
 
     virtual void setUIType(QML_UI_TYPE eUI_Type) const
     {
-        assert(m_eUIType == QML_UI_UNKNOWN || m_eUIType == eUI_Type);
+        //assert(m_eUIType == QML_UI_UNKNOWN || m_eUIType == eUI_Type);
         m_eUIType = eUI_Type;
     }
 

--- a/configurator/SchemaComplexType.cpp
+++ b/configurator/SchemaComplexType.cpp
@@ -254,6 +254,40 @@ void CComplexType::getQML2(StringBuffer &strQML, int idx) const
         assert(!"what am i?");
     }
 }
+void CComplexType::getQML3(StringBuffer &strQML, int idx) const
+{
+    if (m_pAttributeArray != NULL && m_pAttributeArray->length() > 0)
+    {
+        DEBUG_MARK_QML;
+        if( m_pSequence             == NULL && 
+            m_pAttributeGroupArray  == NULL)
+        {
+            m_pAttributeArray->setUIType(this->getUIType());
+            m_pAttributeArray->getQML3(strQML);
+        } 
+        else 
+        {
+            CQMLMarkupHelper::buildAccordionStart(strQML, "Attributes");
+            m_pAttributeArray->setUIType(this->getUIType());
+            m_pAttributeArray->getQML3(strQML);
+            strQML.append(QML_DOUBLE_END_BRACKET);
+        }
+        DEBUG_MARK_QML;
+    }
+    if (m_pSequence != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pSequence->getQML3(strQML);
+        DEBUG_MARK_QML;
+    }
+    if(m_pAttributeGroupArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pAttributeGroupArray->getQML3(strQML);
+        DEBUG_MARK_QML;
+    }
+    
+}
 /*
 
     if ((m_pSequence != NULL || (m_pAttributeArray != NULL && m_pAttributeArray->length() > 0)) && this->getUIType() != QML_UI_TABLE)
@@ -539,6 +573,16 @@ void CComplexTypeArray::getQML2(StringBuffer &strQML, int idx) const
     {
         DEBUG_MARK_QML;
         (this->item(idx)).getQML2(strQML);
+        DEBUG_MARK_QML;
+    }
+}
+void CComplexTypeArray::getQML3(StringBuffer &strQML, int idx) const
+{
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        DEBUG_MARK_QML;
+        (this->item(idx)).setUIType(this->getUIType());
+        (this->item(idx)).getQML3(strQML);
         DEBUG_MARK_QML;
     }
 }

--- a/configurator/SchemaComplexType.hpp
+++ b/configurator/SchemaComplexType.hpp
@@ -34,6 +34,7 @@ public:
 
     virtual void getQML(StringBuffer &strQML, int idx = -1) const;
     virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
 
     virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
 
@@ -109,6 +110,7 @@ public:
 
     virtual void getQML(StringBuffer &strQML, int idx = -1) const;
     virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
 
     virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
 

--- a/configurator/SchemaElement.cpp
+++ b/configurator/SchemaElement.cpp
@@ -1,6 +1,8 @@
 #include <cassert>
 #include "jptree.hpp"
 #include "jstring.hpp"
+#include "jarray.hpp"
+#include "jhash.hpp"
 #include "XMLTags.h"
 #include "SchemaAnnotation.hpp"
 #include "SchemaCommon.hpp"
@@ -1009,129 +1011,39 @@ void CElement::getQML2(StringBuffer &strQML, int idx) const
 
     }
 }
-    /*else if (this->hasChildElements() == true || this->getMaxOccursInt() == 1)
+void CElement::getQML3(StringBuffer &strQML, int idx) const
+{
+    DEBUG_MARK_QML;
+    if (m_pComplexTypeArray != NULL)
     {
-        this->setUIType(QML_UI_TAB);
-
-        CQMLMarkupHelper::getTabQML(strQML, this->getTitle());
-        DEBUG_MARK_QML;
-        strQML.append(QML_GRID_LAYOUT_BEGIN_1);
-        DEBUG_MARK_QML;
-
-        if (m_pAnnotation != NULL)
-        {
-            DEBUG_MARK_QML2(this);
-            m_pAnnotation->getQML2(strQML);
-            DEBUG_MARK_QML2(this);
-        }
-
-        if (m_pComplexTypeArray != NULL && m_pComplexTypeArray->length() > 0)
-        {
-            if (this->hasChildElements() == true)
-            {
-                strQML.append(QML_TAB_VIEW_BEGIN);
-                DEBUG_MARK_QML
-
-                DEBUG_MARK_QML2(this);
-                m_pComplexTypeArray->getQML2(strQML);
-                DEBUG_MARK_QML2(this);
-            }
-            else
-            {
-
-            }
-
-            if (this->hasChildElements() == true)
-            {
-                strQML.append(QML_TAB_VIEW_STYLE);
-                DEBUG_MARK_QML;
-                strQML.append(QML_TAB_VIEW_END);
-                DEBUG_MARK_QML;
-                strQML.append(QML_TAB_TEXT_STYLE);
-                DEBUG_MARK_QML;
-            }
-        }
-
-        strQML.append(QML_GRID_LAYOUT_END);
-        DEBUG_MARK_QML;
-        strQML.append(QML_FLICKABLE_HEIGHT).append(CQMLMarkupHelper::getImplicitHeight() * 1.5);
-        DEBUG_MARK_QML;
-        strQML.append(QML_FLICKABLE_END);
-        DEBUG_MARK_QML;
-        strQML.append(QML_TAB_END);
-        DEBUG_MARK_QML;
-    }
-    else if (this->getMaxOccursInt() > 1)
-    {
-        this->setUIType(QML_UI_TABLE);
-
-        strQML.append(QML_TABLE_VIEW_BEGIN);
-        DEBUG_MARK_QML;
-
-        strQML.append(QML_MODEL).append(modelNames[CConfigSchemaHelper::getInstance(0)->getNumberOfTables()]).append(QML_STYLE_NEW_LINE);
-        DEBUG_MARK_QML;
-
-        strQML.append(QML_PROPERTY_STRING_TABLE_BEGIN).append(modelNames[CConfigSchemaHelper::getInstance(0)->getNumberOfTables()]).append(QML_PROPERTY_STRING_TABLE_PART_1).append(this->getXSDXPath()).append(QML_PROPERTY_STRING_TABLE_END);
-        DEBUG_MARK_QML;
-
-        CConfigSchemaHelper::getInstance(0)->incTables();
-
-        if (m_pComplexTypeArray != NULL)
+        if(this->getUIType() == QML_UI_TABLE_LIST)
         {
             DEBUG_MARK_QML;
-            m_pComplexTypeArray->getQML2(strQML);
-            DEBUG_MARK_QML;
+            m_pComplexTypeArray->setUIType(this->getUIType());
+            m_pComplexTypeArray->getQML3(strQML);
         }
-
-        DEBUG_MARK_QML;
-        strQML.append(QML_TABLE_VIEW_END);
-        DEBUG_MARK_QML;
-    }
-    else if (this->getUIType() == QML_UI_EMPTY)
-    {
-        DEBUG_MARK_QML;
-
-        if (m_pComplexTypeArray != NULL)
-        {*/
-            /*strQML.append(QML_TAB_VIEW_BEGIN);
+        else 
+        {
+            const char * altTitle = "";
+            if((m_pComplexTypeArray->item(0)).getAttributeArray() != NULL){
+                if((m_pComplexTypeArray->item(0)).getAttributeArray()->findAttributeWithName("name") != NULL){
+                    altTitle = (m_pComplexTypeArray->item(0)).getAttributeArray()->findAttributeWithName("name")->getEnvXPath();
+                }
+            }
+    
             DEBUG_MARK_QML;
-            CQMLMarkupHelper::getTabQML(strQML, this->getTitle());
+            /*if(!stricmp(getMaxOccurs(),"unbounded")) // If unbounded, print index
+                CQMLMarkupHelper::buildAccordionStart(strQML, this->getTitle(), altTitle, idx);
+            else // Otherwise, don't*/
+                CQMLMarkupHelper::buildAccordionStart(strQML, this->getTitle(), altTitle);
             DEBUG_MARK_QML;
-            strQML.append(QML_GRID_LAYOUT_BEGIN_1);
-            DEBUG_MARK_QML;*/
-
-         /*   DEBUG_MARK_QML;
-            //m_pComplexTypeArray->setUIType(QML_UI_TEXT_FIELD);
-            //m_pComplexTypeArray->setUIType(QML_UI_TAB);
-            m_pComplexTypeArray->getQML2(strQML,idx);
-            DEBUG_MARK_QML;
-
-            /*strQML.append(QML_GRID_LAYOUT_END);
-            DEBUG_MARK_QML;
-            strQML.append(QML_FLICKABLE_HEIGHT).append(CQMLMarkupHelper::getImplicitHeight() * 1.5);
-            DEBUG_MARK_QML;
-            strQML.append(QML_FLICKABLE_END);
-            DEBUG_MARK_QML;
-            strQML.append(QML_TAB_END);
-            DEBUG_MARK_QML;
-            strQML.append(QML_TAB_VIEW_STYLE);
-            DEBUG_MARK_QML;
-            strQML.append(QML_TAB_VIEW_END);
-            DEBUG_MARK_QML;
-            strQML.append(QML_TAB_TEXT_STYLE);
+            m_pComplexTypeArray->getQML3(strQML);
+            strQML.append(QML_DOUBLE_END_BRACKET);
             DEBUG_MARK_QML;
         }
     }
-    else if (this->getConstParentNode()->getUIType() == QML_UI_TAB)
-    {
-
-    }
-    else
-    {
-        assert(!"what am i?");
-    }
-
-}*/
+    DEBUG_MARK_QML;
+}
 
 bool CElement::isATab() const
 {
@@ -1307,6 +1219,18 @@ bool CElement::isTopLevelElement() const
     //*/return m_bTopLevelElement;
 }
 
+const char * CElement::getViewType() const
+{
+    if(m_pAnnotation != NULL){
+        if(m_pAnnotation->getAppInfo() != NULL){
+            if(m_pAnnotation->getAppInfo()->getViewType() != NULL){
+                return this->getAnnotation()->getAppInfo()->getViewType();
+            }
+        }
+    }
+    return NULL;
+}
+
 void CElementArray::dump(std::ostream &cout, unsigned int offset) const
 {
     offset+= STANDARD_OFFSET_1;
@@ -1407,6 +1331,73 @@ void CElementArray::getQML2(StringBuffer &strQML, int idx) const
         DEBUG_MARK_QML;
         this->item(0).getQML2(strQML,0);
         DEBUG_MARK_QML;
+    }
+}
+
+void CElementArray::getQML3(StringBuffer &strQML, int idx) const
+{
+    DEBUG_MARK_QML;
+    if(this->length() > 1){
+        
+        StructArrayOf<StringBuffer> keyspace;
+        MapStringTo<bool,bool> isList;
+        MapStringTo<StringBuffer,const char *> elementGroups;
+        // Go through Element Array to initialize elementGroups
+        for (int i = 0; i < this->length(); i++) 
+        {
+            // If this is a unique element name
+            if(elementGroups.getValue((this->item(i)).getName()) == NULL){
+                // Initialize temp string
+                StringBuffer temp("");
+                // Build Accordion
+                CQMLMarkupHelper::buildAccordionStart(temp,(this->item(i)).getTitle());
+                // If list or instance, append table boilerplate, make mapping for later
+                if( (this->item(i)).getViewType() != NULL && 
+                    (!stricmp((this->item(i)).getViewType(),"list") || !stricmp((this->item(i)).getViewType(),"instance")) &&
+                    (this->item(i)).getComplexTypeArray() != NULL &&
+                    ((this->item(i)).getComplexTypeArray()->item(0)).getSequence() == NULL &&
+                    ((this->item(i)).getComplexTypeArray()->item(0)).getAttributeGroupArray() == NULL && 
+                    ((this->item(i)).getComplexTypeArray()->item(0)).getAttributeArray() != NULL && 
+                    ((this->item(i)).getComplexTypeArray()->item(0)).getAttributeArray()->length() > 0
+                    )
+                {
+                    isList.setValue((this->item(i)).getName(),true);
+                    temp.append(QML_TABLE_START);
+                    StructArrayOf<StringBuffer> names;
+                    StructArrayOf<StringBuffer> titles;
+                    ((this->item(i)).getComplexTypeArray()->item(0)).getAttributeArray()->getAttributeNames(names,titles);
+                    CQMLMarkupHelper::buildColumns(temp, names, titles);
+                    temp.append(QML_TABLE_CONTENT_START);
+                } else {
+                    isList.setValue((this->item(i)).getName(),false);
+                }
+                // Save grouping, save keyspace for reference
+                elementGroups.setValue((this->item(i)).getName(),temp.str());
+                keyspace.append((this->item(i)).getName());
+            }
+        }
+        for (int i = 0; i < this->length(); i++)
+        {
+            assert(*elementGroups.getValue((this->item(i)).getName()) != NULL);
+            if(*elementGroups.getValue((this->item(i)).getName()) != NULL){
+                StringBuffer temp = *elementGroups.getValue((this->item(i)).getName());
+                if(*isList.getValue((this->item(i)).getName()) == true){
+                    (this->item(i)).setUIType(QML_UI_TABLE_LIST);
+                }
+                (this->item(i)).getQML3(temp,i);
+                elementGroups.setValue((this->item(i)).getName(),temp.str());
+            }
+        }
+        for(int i = 0; i < keyspace.length(); i++){
+            strQML.append(*elementGroups.getValue(keyspace[i]));
+            DEBUG_MARK_QML;
+            if(*isList.getValue(keyspace[i]) == true)
+                strQML.append(QML_DOUBLE_END_BRACKET);
+            strQML.append(QML_DOUBLE_END_BRACKET);
+            DEBUG_MARK_QML;
+        }
+    } else {
+        (this->item(0)).getQML3(strQML,0);
     }
 }
 

--- a/configurator/SchemaElement.cpp
+++ b/configurator/SchemaElement.cpp
@@ -1035,7 +1035,7 @@ void CElement::getQML3(StringBuffer &strQML, int idx) const
             /*if(!stricmp(getMaxOccurs(),"unbounded")) // If unbounded, print index
                 CQMLMarkupHelper::buildAccordionStart(strQML, this->getTitle(), altTitle, idx);
             else // Otherwise, don't*/
-                CQMLMarkupHelper::buildAccordionStart(strQML, this->getTitle(), altTitle);
+            CQMLMarkupHelper::buildAccordionStart(strQML, this->getTitle(), altTitle);
             DEBUG_MARK_QML;
             m_pComplexTypeArray->getQML3(strQML);
             strQML.append(QML_DOUBLE_END_BRACKET);

--- a/configurator/SchemaElement.cpp
+++ b/configurator/SchemaElement.cpp
@@ -1025,16 +1025,12 @@ void CElement::getQML3(StringBuffer &strQML, int idx) const
         else 
         {
             const char * altTitle = "";
-            if((m_pComplexTypeArray->item(0)).getAttributeArray() != NULL){
-                if((m_pComplexTypeArray->item(0)).getAttributeArray()->findAttributeWithName("name") != NULL){
-                    altTitle = (m_pComplexTypeArray->item(0)).getAttributeArray()->findAttributeWithName("name")->getEnvXPath();
-                }
+            if((m_pComplexTypeArray->item(0)).getAttributeArray() != NULL && (m_pComplexTypeArray->item(0)).getAttributeArray()->findAttributeWithName("name") != NULL)
+            {
+                altTitle = (m_pComplexTypeArray->item(0)).getAttributeArray()->findAttributeWithName("name")->getEnvXPath();
             }
     
             DEBUG_MARK_QML;
-            /*if(!stricmp(getMaxOccurs(),"unbounded")) // If unbounded, print index
-                CQMLMarkupHelper::buildAccordionStart(strQML, this->getTitle(), altTitle, idx);
-            else // Otherwise, don't*/
             CQMLMarkupHelper::buildAccordionStart(strQML, this->getTitle(), altTitle);
             DEBUG_MARK_QML;
             m_pComplexTypeArray->getQML3(strQML);
@@ -1221,12 +1217,9 @@ bool CElement::isTopLevelElement() const
 
 const char * CElement::getViewType() const
 {
-    if(m_pAnnotation != NULL){
-        if(m_pAnnotation->getAppInfo() != NULL){
-            if(m_pAnnotation->getAppInfo()->getViewType() != NULL){
-                return this->getAnnotation()->getAppInfo()->getViewType();
-            }
-        }
+    if(m_pAnnotation != NULL && m_pAnnotation->getAppInfo() != NULL)
+    {
+        return m_pAnnotation->getAppInfo()->getViewType();
     }
     return NULL;
 }
@@ -1337,16 +1330,17 @@ void CElementArray::getQML2(StringBuffer &strQML, int idx) const
 void CElementArray::getQML3(StringBuffer &strQML, int idx) const
 {
     DEBUG_MARK_QML;
-    if(this->length() > 1){
-        
-        StructArrayOf<StringBuffer> keyspace;
+    if(this->length() > 1)
+    {
+        StringArray keyspace;
         MapStringTo<bool,bool> isList;
         MapStringTo<StringBuffer,const char *> elementGroups;
         // Go through Element Array to initialize elementGroups
         for (int i = 0; i < this->length(); i++) 
         {
             // If this is a unique element name
-            if(elementGroups.getValue((this->item(i)).getName()) == NULL){
+            if(elementGroups.getValue((this->item(i)).getName()) == NULL)
+            {
                 // Initialize temp string
                 StringBuffer temp("");
                 // Build Accordion
@@ -1363,8 +1357,8 @@ void CElementArray::getQML3(StringBuffer &strQML, int idx) const
                 {
                     isList.setValue((this->item(i)).getName(),true);
                     temp.append(QML_TABLE_START);
-                    StructArrayOf<StringBuffer> names;
-                    StructArrayOf<StringBuffer> titles;
+                    StringArray names;
+                    StringArray titles;
                     ((this->item(i)).getComplexTypeArray()->item(0)).getAttributeArray()->getAttributeNames(names,titles);
                     CQMLMarkupHelper::buildColumns(temp, names, titles);
                     temp.append(QML_TABLE_CONTENT_START);
@@ -1379,16 +1373,19 @@ void CElementArray::getQML3(StringBuffer &strQML, int idx) const
         for (int i = 0; i < this->length(); i++)
         {
             assert(*elementGroups.getValue((this->item(i)).getName()) != NULL);
-            if(*elementGroups.getValue((this->item(i)).getName()) != NULL){
+            if(*elementGroups.getValue((this->item(i)).getName()) != NULL)
+            {
                 StringBuffer temp = *elementGroups.getValue((this->item(i)).getName());
-                if(*isList.getValue((this->item(i)).getName()) == true){
+                if(*isList.getValue((this->item(i)).getName()) == true)
+                {
                     (this->item(i)).setUIType(QML_UI_TABLE_LIST);
                 }
                 (this->item(i)).getQML3(temp,i);
                 elementGroups.setValue((this->item(i)).getName(),temp.str());
             }
         }
-        for(int i = 0; i < keyspace.length(); i++){
+        for(int i = 0; i < keyspace.length(); i++)
+        {
             strQML.append(*elementGroups.getValue(keyspace[i]));
             DEBUG_MARK_QML;
             if(*isList.getValue(keyspace[i]) == true)

--- a/configurator/SchemaElement.hpp
+++ b/configurator/SchemaElement.hpp
@@ -46,6 +46,8 @@ public:
 
     virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
 
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+
     virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
 
     virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
@@ -143,6 +145,8 @@ public:
 
     static CElement* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath, bool bIsInXSD = true);
 
+    const char * getViewType() const;
+
     GETTERSETTER(Name)
     GETTERSETTER(MaxOccurs)
     GETTERSETTER(MinOccurs)
@@ -204,6 +208,7 @@ public:
 
     virtual void getQML(StringBuffer &strQML, int idx = -1) const;
     virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
 
     virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
 

--- a/configurator/SchemaSchema.cpp
+++ b/configurator/SchemaSchema.cpp
@@ -326,6 +326,49 @@ void CSchema::getQML2(StringBuffer &strQML, int idx) const
     DEBUG_MARK_QML;
 }
 
+void CSchema::getQML3(StringBuffer &strQML, int idx) const
+{
+    // Generates QML ListModel
+    DEBUG_MARK_QML;
+    strQML.append(QML_FILE_START);
+
+    if (m_pElementArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pElementArray->getQML3(strQML, idx);
+        DEBUG_MARK_QML;
+    }
+    /*if (m_pComplexTypeArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        assert(!"Is this valid?");
+        m_pComplexTypeArray->getQML2(strQML);
+        DEBUG_MARK_QML;
+    }
+    if (m_pAttributeGroupArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pAttributeGroupArray->getQML2(strQML);
+        DEBUG_MARK_QML;
+    }
+    if (m_pSimpleTypeArray != NULL)
+    {
+        //assert(!"Is this valid?");
+        DEBUG_MARK_QML;
+        m_pSimpleTypeArray->getQML2(strQML);
+        DEBUG_MARK_QML;
+    }
+    if (m_pIncludeArray != NULL)
+    {
+        //assert(!"Is this valid?");
+        DEBUG_MARK_QML;
+        m_pIncludeArray->getQML2(strQML);
+        DEBUG_MARK_QML;
+    }*/
+
+    strQML.append(QML_DOUBLE_END_BRACKET);
+}
+
 void  CSchema::populateEnvXPath(StringBuffer strXPath, unsigned int index)
 {
     strXPath.append("./").append(XML_TAG_SOFTWARE);

--- a/configurator/SchemaSchema.hpp
+++ b/configurator/SchemaSchema.hpp
@@ -24,6 +24,7 @@ public:
 
     virtual void getQML(StringBuffer &strQML, int idx = -1) const;
     virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
 
     virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
 

--- a/configurator/SchemaSequence.cpp
+++ b/configurator/SchemaSequence.cpp
@@ -15,9 +15,9 @@ const CXSDNodeBase* CSequence::getNodeByTypeAndNameDescending(NODE_TYPES eNodeTy
         return this;
     }
 
-    if (p_mElementArray != NULL)
+    if (m_pElementArray != NULL)
     {
-        pMatchingNode = p_mElementArray->getNodeByTypeAndNameDescending(eNodeType, pName);
+        pMatchingNode = m_pElementArray->getNodeByTypeAndNameDescending(eNodeType, pName);
     }
 
     return pMatchingNode;
@@ -67,9 +67,9 @@ void CSequence::dump(std::ostream& cout, unsigned int offset) const
 
     QUICK_OUT(cout, XSDXPath,  offset);
 
-    if (p_mElementArray != NULL)
+    if (m_pElementArray != NULL)
     {
-        p_mElementArray->dump(cout, offset);
+        m_pElementArray->dump(cout, offset);
     }
 
     QuickOutFooter(cout, XSD_SEQUENCE_STR, offset);
@@ -77,50 +77,50 @@ void CSequence::dump(std::ostream& cout, unsigned int offset) const
 
 void CSequence::getDocumentation(StringBuffer &strDoc) const
 {
-    if (p_mElementArray != NULL)
+    if (m_pElementArray != NULL)
     {
-        p_mElementArray->getDocumentation(strDoc);
+        m_pElementArray->getDocumentation(strDoc);
     }
 }
 
 void CSequence::getDojoJS(StringBuffer &strJS) const
 {
-    if (p_mElementArray != NULL)
+    if (m_pElementArray != NULL)
     {
-        p_mElementArray->getDojoJS(strJS);
+        m_pElementArray->getDojoJS(strJS);
     }
 }
 
 void CSequence::getQML(StringBuffer &strQML, int idx) const
 {
-    if (p_mElementArray != NULL)
+    if (m_pElementArray != NULL)
     {
-        p_mElementArray->getQML(strQML);
+        m_pElementArray->getQML(strQML);
     }
 }
 
 void CSequence::getQML2(StringBuffer &strQML, int idx) const
 {
-    if (p_mElementArray != NULL)
+    if (m_pElementArray != NULL)
     {
         this->setUIType(this->getParentNode()->getUIType());
-        p_mElementArray->getQML2(strQML);
+        m_pElementArray->getQML2(strQML);
     }
 }
 
 void CSequence::getQML3(StringBuffer &strQML, int idx) const
 {   
-    if (p_mElementArray != NULL)
+    if (m_pElementArray != NULL)
     {
-        p_mElementArray->getQML3(strQML);
+        m_pElementArray->getQML3(strQML);
     }
 }
 
 void CSequence::populateEnvXPath(StringBuffer strXPath, unsigned int index)
 {
-    if (p_mElementArray != NULL)
+    if (m_pElementArray != NULL)
     {
-        p_mElementArray->populateEnvXPath(strXPath);
+        m_pElementArray->populateEnvXPath(strXPath);
     }
 
     this->setEnvXPath(strXPath);
@@ -128,15 +128,15 @@ void CSequence::populateEnvXPath(StringBuffer strXPath, unsigned int index)
 
 void CSequence::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
 {
-    if (p_mElementArray != NULL)
+    if (m_pElementArray != NULL)
     {
-        p_mElementArray->loadXMLFromEnvXml(pEnvTree);
+        m_pElementArray->loadXMLFromEnvXml(pEnvTree);
     }
 }
 
 bool CSequence::hasChildElements() const
 {
-    if (this->p_mElementArray->length() > 0)
+    if (this->m_pElementArray->length() > 0)
     {
         return true;
     }

--- a/configurator/SchemaSequence.cpp
+++ b/configurator/SchemaSequence.cpp
@@ -108,6 +108,14 @@ void CSequence::getQML2(StringBuffer &strQML, int idx) const
     }
 }
 
+void CSequence::getQML3(StringBuffer &strQML, int idx) const
+{   
+    if (p_mElementArray != NULL)
+    {
+        p_mElementArray->getQML3(strQML);
+    }
+}
+
 void CSequence::populateEnvXPath(StringBuffer strXPath, unsigned int index)
 {
     if (p_mElementArray != NULL)

--- a/configurator/SchemaSequence.hpp
+++ b/configurator/SchemaSequence.hpp
@@ -30,6 +30,8 @@ public:
 
     virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
 
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+
     virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
 
     virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);

--- a/configurator/SchemaSequence.hpp
+++ b/configurator/SchemaSequence.hpp
@@ -10,7 +10,7 @@ class CSequence : public CXSDNode
 {
 public:
 
-    CSequence(CXSDNodeBase* pParentNode = NULL, CElementArray* pElemArray = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_SEQUENCE), p_mElementArray(pElemArray)
+    CSequence(CXSDNodeBase* pParentNode = NULL, CElementArray* pElemArray = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_SEQUENCE), m_pElementArray(pElemArray)
     {
     }
 
@@ -42,7 +42,7 @@ public:
 
 protected:
 
-    CElementArray *p_mElementArray;
+    CElementArray *m_pElementArray;
 
 private:
 

--- a/configurator_app/MainWindow.cpp
+++ b/configurator_app/MainWindow.cpp
@@ -151,7 +151,8 @@ void MainWindow::on_treeView_clicked(const QModelIndex &index)
 {
     QUrl url;
     //QString qstrQML(CONFIGURATOR_API::getQML(index.internalPointer()));
-    QString qstrFileName("/tmp/");
+    //QString qstrFileName("/tmp/");
+    QString qstrFileName("qml/");
     qstrFileName.append(CONFIGURATOR_API::getFileName(index.internalPointer()));
     qstrFileName.append(".qml");
 

--- a/configurator_app/MainWindow.cpp
+++ b/configurator_app/MainWindow.cpp
@@ -151,8 +151,7 @@ void MainWindow::on_treeView_clicked(const QModelIndex &index)
 {
     QUrl url;
     //QString qstrQML(CONFIGURATOR_API::getQML(index.internalPointer()));
-    //QString qstrFileName("/tmp/");
-    QString qstrFileName("qml/");
+    QString qstrFileName("/tmp/");
     qstrFileName.append(CONFIGURATOR_API::getFileName(index.internalPointer()));
     qstrFileName.append(".qml");
 

--- a/lib_qml/AccordionItem.qml
+++ b/lib_qml/AccordionItem.qml
@@ -1,0 +1,147 @@
+import QtQuick 2.4
+
+Rectangle {
+    id: accordion
+    property string title
+    property string altTitle
+    property int index : -5
+    property var originalParent : parent
+    property var colorSchemePicker:[
+		["#1be7ff","#6eeb83","#e4ff1a","#e8aa14","#ff5714"],
+		["#ed6a5a","#f4f1bb","#9bc1bc","#5ca4a9","#e6ebe0"],
+		["#ff4e00","#8ea604","#f5bb00","#ec9f05","#bf3100"],
+		["#e3b505","#95190c","#610345","#107e7d","#044b7f"],
+		["#69995d","#cbac88","#edb6a3","#d2f1e4","#f8e9e9"],
+		["#69995d","#84dcc6","#cbac88","#f8e9e9","#D3BEFF"], // Runner up?
+		["#41771F","#F24141","#ffe066","#247ba0","#70c1b3"], // Me Gusta
+		["#41771F","#F24141","#ffe066","#247ba0","#4CB963"], // Similar to Above, imo better
+		["#247ba0","#70c1b3","#b2dbbf","#f3ffbd","#ff1654"],
+		["#05668d","#028090","#00a896","#02c39a","#f0f3bd"],
+    ]
+    property var colorScheme: colorSchemePicker[7]
+    property alias contentModel: theContentModel.sourceComponent
+	property int nest: parent ? parent.parent ? parent.parent.nest >= -1 ? parent.parent.nest + 1 : 1 : 1 : 1
+	property int originalNest: nest
+	property bool expanded: false
+	layer.enabled: true
+    color: {
+    	return colorScheme[nest%colorScheme.length]}
+	border.color: "black"
+	border.width: 2
+    anchors.left: parent ? parent.left : root.left
+    anchors.right: parent ? parent.right : root.right
+    implicitHeight: titleText.height + itemView.contentHeight + 12
+    height: titleText.height + 8
+
+    Binding on height{
+    	when: expanded
+    	value: titleText.height + itemView.contentHeight + 12
+    }
+
+    Behavior on height { 
+    	PropertyAnimation {
+	    	duration: 200
+	    	easing.type: Easing.OutQuad
+    	} 
+    }
+
+	state:""
+	states: [
+		State {
+			name: "EXPANDED"
+			StateChangeScript {script: {
+		    		
+			}}
+			ParentChange{
+				target: accordion
+				parent: scrollRoot
+			}
+			PropertyChanges{
+				target: accordion
+				nest: originalNest
+			}
+			AnchorChanges{
+				target: accordion
+				anchors.top: parent == null ? undefined : parent.top
+			}
+		}
+	]
+	transitions: Transition {
+        AnchorAnimation {
+            duration: 500
+            easing.type: Easing.OutQuad 
+        }
+        ParentAnimation {
+            NumberAnimation { 
+            	duration: 500
+            	easing.type: Easing.OutQuad 
+            }
+            ScriptAction {script:{
+            	if(state == "")
+            		listRoot.visibility = listRoot.visibility - 1
+            	else if(state == "EXPANDED")
+            		listRoot.visibility = listRoot.visibility + 1
+            	console.log(listRoot.visibility)
+            }}
+        }
+
+    }
+
+	Text {
+    	id: titleText
+    	text: (altTitle ? (typeof ApplicationData != 'undefined' ? ApplicationData.getValue(altTitle) : altTitle) + "|" : "") + title
+		anchors.horizontalCenter: parent.horizontalCenter
+		anchors.top: parent.top
+		anchors.topMargin: 4
+
+	    MouseArea {
+	    	width: accordion.width
+	    	height: parent.height
+	    	anchors.horizontalCenter: parent.horizontalCenter
+	    	onClicked: {
+	    		expanded = !expanded
+	    	}
+		}
+	}
+	Rectangle{
+		anchors.top: titleText.top
+		anchors.bottom: titleText.bottom
+		anchors.left: titleText.right
+		anchors.leftMargin: 100
+		width: 100
+		color: "blue"
+		visible: originalNest != 1
+		MouseArea {
+	        anchors.fill: parent
+	        onClicked: {
+	        	switch(accordion.state){
+	        		case "":
+	        			accordion.state = "EXPANDED"
+	        			break;
+	        		case "EXPANDED":
+	        			accordion.state = ""
+	        			break;
+	        	}
+	        }
+	    }
+	}
+
+	Loader {
+		id: theContentModel
+	}
+
+	ListView {
+		id: itemView
+		model: theContentModel.item
+		property int nest: accordion.nest
+		visible: expanded
+
+		spacing: 8
+		anchors.left: accordion.left
+		anchors.right: accordion.right
+		anchors.top: titleText.bottom
+		anchors.bottom: accordion.bottom
+		anchors.leftMargin: 8
+		anchors.rightMargin: 8
+	}
+}

--- a/lib_qml/AccordionItem.qml
+++ b/lib_qml/AccordionItem.qml
@@ -4,7 +4,8 @@ Rectangle {
     id: accordion
     property string title
     property string altTitle
-    property int index : -5
+    property bool edited: false
+    property int index : -1
     property var originalParent : parent
     property var colorSchemePicker:[
 		["#1be7ff","#6eeb83","#e4ff1a","#e8aa14","#ff5714"],
@@ -49,7 +50,7 @@ Rectangle {
 	states: [
 		State {
 			name: "EXPANDED"
-			StateChangeScript {script: {
+			StateChangeScript { script: {
 		    		
 			}}
 			ParentChange{
@@ -76,7 +77,7 @@ Rectangle {
             	duration: 500
             	easing.type: Easing.OutQuad 
             }
-            ScriptAction {script:{
+            ScriptAction { script:{
             	if(state == "")
             		listRoot.visibility = listRoot.visibility - 1
             	else if(state == "EXPANDED")
@@ -89,7 +90,8 @@ Rectangle {
 
 	Text {
     	id: titleText
-    	text: (altTitle ? (typeof ApplicationData != 'undefined' ? ApplicationData.getValue(altTitle) : altTitle) + "|" : "") + title
+    	text: (altTitle ? (typeof ApplicationData != 'undefined' ? ApplicationData.getValue(altTitle) : altTitle) + "|" : "") + title + (edited ? "*" :"")
+        font.bold: edited
 		anchors.horizontalCenter: parent.horizontalCenter
 		anchors.top: parent.top
 		anchors.topMargin: 4

--- a/lib_qml/Table.qml
+++ b/lib_qml/Table.qml
@@ -23,7 +23,18 @@ Item{
 	Component {
 		id: fieldCol
 		TextField{
-			text: (value ? (typeof ApplicationData != 'undefined' ? (ApplicationData.getValue(value) ? ApplicationData.getValue(value) : value) : value) : "")
+			text: {
+                var result = value;
+                if (typeof ApplicationData != 'undefined' && value){
+                    result = ApplicationData.getValue(value);
+                    console.log(value + "|" + result)
+                    if(!result){
+                        console.log("I didn't like the result: ", result)
+                        result = ""
+                    }
+                }
+                return result;
+            }
 			placeholderText: placeholder
 			onEditingFinished: {
 				if(typeof ApplicationData != 'undefined')
@@ -47,7 +58,6 @@ Item{
 					}
 				}
 				return result;
-				//return (value ? (typeof ApplicationData != 'undefined' ? (ApplicationData.getValue(value) ? (ApplicationData.getValue(value) != "lol" ? ApplicationData.getValue(value) : value ) : value) : value) : (placeholder ? placeholder : ""))
 			}
 		}
 	}

--- a/lib_qml/Table.qml
+++ b/lib_qml/Table.qml
@@ -1,0 +1,111 @@
+import QtQuick 2.4
+import QtQuick.Controls 1.3
+import QtQml.Models 2.1
+
+Item{
+	id: root
+	property var columnNames
+	property alias tableContent: tableContent.sourceComponent
+	width: parent ? parent.width : 500
+	height: childrenRect.height
+	layer.enabled: true
+
+
+	Loader {
+		id: tableContent
+	}
+
+	Component
+	{
+	    id: columnComponent
+	    TableViewColumn{width: 100 }
+	}
+	Component {
+		id: fieldCol
+		TextField{
+			text: (value ? (typeof ApplicationData != 'undefined' ? (ApplicationData.getValue(value) ? ApplicationData.getValue(value) : value) : value) : "")
+			placeholderText: placeholder
+			onEditingFinished: {
+				if(typeof ApplicationData != 'undefined')
+				{
+					console.log("Setting text \"" + text + "\" to xpath \"" + value + "\"")
+					ApplicationData.setValue(value,text)
+				}
+			}
+		}
+	}
+	Component{
+		id: textCol
+		Text{
+			text: {
+				var result = value;
+				if (typeof ApplicationData != 'undefined' && value){
+					result = ApplicationData.getValue(value);
+					if(!result){
+						console.log("I didn't like the result: ", result)
+						result = ""
+					}
+				}
+				return result;
+				//return (value ? (typeof ApplicationData != 'undefined' ? (ApplicationData.getValue(value) ? (ApplicationData.getValue(value) != "lol" ? ApplicationData.getValue(value) : value ) : value) : value) : (placeholder ? placeholder : ""))
+			}
+		}
+	}
+	Component{
+		id: comboCol
+		ComboBox{
+			model: value
+		}
+	}
+	TableView {
+	    id: view
+	    width: parent.width
+	    model: tableContent.item
+	    resources:
+	    {
+	        var temp = []
+	        for(var i=0; i<columnNames.length; i++)
+	        {
+	            var column  = columnNames[i]
+	            temp.push(columnComponent.createObject(view, { "role": column.role, "title": column.title, "width": Qt.binding(function(){return (parent.width/columnNames.length)-16;})}))
+	        }
+	        return temp
+	    }
+	    itemDelegate: Component{
+	    	Loader {
+    			property var value: {
+    				var result = []
+    				if(styleData.value.get(0)['type'] != null && styleData.value.get(0)['type'] == "combo"){
+    					for(var i = 0; i < styleData.value.get(0)['value'].count; i++){
+    						result.push(styleData.value.get(0)['value'].get(i)['value'])
+    					}
+    				} else {
+    					result = styleData.value.get(0)['value'].get(0)['value']
+    				}
+    				return result
+    			}
+                property string placeholder: styleData.value.get(0)['placeholder'] ? styleData.value.get(0)['placeholder'] : ""
+                property string tooltip: styleData.value.get(0)['tooltip'] ? styleData.value.get(0)['tooltip'] : ""
+                property string viewType: styleData.value.get(0)['type'] ? styleData.value.get(0)['type'] : "text"
+                sourceComponent: {
+                    switch (viewType){
+                        case "text":
+                            return textCol
+                            break;
+                        case "field":
+                            return fieldCol
+                            break;
+                        case "combo":
+                        	return comboCol
+                        	break;
+                        default: return textCol;
+                    }
+                }
+	    	}
+	    }
+	    rowDelegate: Rectangle{
+	    	height: 20
+	    	color: styleData.alternate ? "lightgrey" : "white"
+	    }
+	}
+}

--- a/lib_qml/Table.qml
+++ b/lib_qml/Table.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls 1.3
 import QtQml.Models 2.1
 
 Item{
-	id: root
+	id: tableRoot
 	property var columnNames
 	property alias tableContent: tableContent.sourceComponent
 	width: parent ? parent.width : 500
@@ -23,7 +23,8 @@ Item{
 	Component {
 		id: fieldCol
 		TextField{
-			text: {
+            property string origText
+            text: {
                 var result = value;
                 if (typeof ApplicationData != 'undefined' && value){
                     result = ApplicationData.getValue(value);
@@ -33,15 +34,20 @@ Item{
                         result = ""
                     }
                 }
+                origText = result;
                 return result;
             }
 			placeholderText: placeholder
 			onEditingFinished: {
-				if(typeof ApplicationData != 'undefined')
-				{
-					console.log("Setting text \"" + text + "\" to xpath \"" + value + "\"")
-					ApplicationData.setValue(value,text)
-				}
+                if(origText != text){
+                        tableRoot.parent.parent.parent.edited = true;
+                    if(typeof ApplicationData != 'undefined')
+                    {
+    					console.log("Setting text \"" + text + "\" to xpath \"" + value + "\"")
+    					ApplicationData.setValue(value,text)
+    				}
+                }
+
 			}
 		}
 	}
@@ -65,6 +71,17 @@ Item{
 		id: comboCol
 		ComboBox{
 			model: value
+            property int origIndex: {origIndex = currentIndex}
+            onActivated:{
+                if(origIndex != currentIndex){
+                    tableRoot.parent.parent.parent.edited = true;
+                    if(typeof ApplicationData != 'undefined')
+                    {
+                        console.log("Setting text \"" + currentText + "\" to xpath \"" + value + "\"")
+                        ApplicationData.setValue(value,currentText)
+                    }
+                }
+            }
 		}
 	}
 	TableView {

--- a/lib_qml/test.qml
+++ b/lib_qml/test.qml
@@ -1,0 +1,201 @@
+import QtQuick 2.4
+import QtQuick.Controls 1.3
+
+Item {
+    id: gRoot
+    width: 900
+    height: 700
+    property alias root: gRoot
+    ScrollView{
+        id: scrollRoot
+        anchors.fill: parent
+        ListView{
+            id: listRoot
+            property int nest: 0
+            property int visibility: 0
+            anchors.fill: parent
+            spacing: 4
+            model: accordionModel
+            opacity: !visibility
+            transitions: Transition {
+                NumberAnimation { properties: "opacity"; easing.type: Easing.InOutQuad; duration: 1000  }
+            }
+        }
+    }
+    VisualItemModel {
+        id: accordionModel
+        AccordionItem{
+            title: "1"
+            contentModel: VisualItemModel {
+                Table{
+                    tableContent: ListModel {
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "A Masterpiece"}] type: "field"; tooltip:"Hey" }
+                            key: ListElement {value: [ListElement{value: "Gabriel"}]}
+                            alphabet: ListElement { value: [ListElement{value: "soup"}] type: "field" }
+                        }
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "Brilliance"}] type: "field"; placeholder: "lel"}
+                            key: ListElement { value: [ListElement{value: "Jens"}] type: "field"}
+                            alphabet: ListElement { value: [ListElement{value: "order"}] }
+                        }
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "Outstanding"}] type: "field"}
+                            key: ListElement { value: [ListElement{value: "Frederik"},ListElement{value: "Jacob"},ListElement{value: "Markus"}] type: "combo" }
+                            alphabet: ListElement { value: [ListElement{value: "yodels"}] }
+                        }
+                    }
+                    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
+                }
+                Table{
+                    tableContent: ListModel {
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "A Masterpiece"}] type: "field"; tooltip:"Hey" }
+                            key: ListElement {value: [ListElement{value: "Gabriel"}]}
+                        }
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "Brilliance"}] type: "field"; placeholder: "lel"}
+                            key: ListElement { value: [ListElement{value: "Jens"}] type: "field"}
+                        }
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "Outstanding"}] type: "field"}
+                            key: ListElement { value: [ListElement{value: "Frederik"},ListElement{value: "Jacob"},ListElement{value: "Markus"}] type: "combo" }
+                        }
+                    }
+                    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"}]
+                }
+                AccordionItem{
+                    title: "2"
+                    contentModel: VisualItemModel {
+                        Text {text: "Hello"}
+                        AccordionItem{
+                            title: "3"
+                            contentModel: VisualItemModel {
+                                AccordionItem{
+                                    title: "4"
+                                    contentModel: VisualItemModel {
+                                        Text {text: "Hello"}
+                                        AccordionItem{
+                                            title: "5"
+                                            contentModel: VisualItemModel {
+                                                Text {text: "Hello"}
+                                                AccordionItem{
+                                                    title: "6"
+                                                    contentModel: VisualItemModel {
+                                                        /*Table{
+                                                            tableContent: ListModel {
+                                                                ListElement {
+                                                                    value: ListElement {value: "A Masterpiece"; type: "field"; tooltip:"Hey" }
+                                                                    key: ListElement {value: "Gabriel"}
+                                                                    alphabet: ListElement { value: "soup" }
+                                                                }
+                                                                ListElement {
+                                                                    value: ListElement {value: "Brilliance"; type: "field"; placeholder: "lel"}
+                                                                    key: ListElement { value: "Jens" }
+                                                                    alphabet: ListElement { value: "order" }
+                                                                }
+                                                                ListElement {
+                                                                    value: ListElement {value: "Outstanding"; type: "field"}
+                                                                    key: ListElement { value: "Frederik" }
+                                                                    alphabet: ListElement { value: "yodels" }
+                                                                }
+                                                            }
+                                                            columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
+                                                        }*/
+                                                        Text {text: "Hello"}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        Text {text: "World"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Text {text: "World"}
+            }
+        }
+        AccordionItem{
+            title: "7"
+            contentModel: VisualItemModel {
+                /*Table{
+                    tableContent: ListModel {
+                        ListElement {
+                            value: ListElement {value: "A Masterpiece"; type: "field"; tooltip:"Hey" }
+                            key: ListElement {value: "Gabriel"}
+                            alphabet: ListElement { value: "soup" }
+                        }
+                        ListElement {
+                            value: ListElement {value: "Brilliance"; type: "field"; placeholder: "lel"}
+                            key: ListElement { value: "Jens" }
+                            alphabet: ListElement { value: "order" }
+                        }
+                        ListElement {
+                            value: ListElement {value: "Outstanding"; type: "field"}
+                            key: ListElement { value: "Frederik" }
+                            alphabet: ListElement { value: "yodels" }
+                        }
+                    }
+                    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
+                }*/
+                Text {text: "Hello"}
+
+            }
+        }
+        AccordionItem{
+            title: "8"
+            contentModel: VisualItemModel {
+                Text {text: "Hello"}
+                AccordionItem{
+                    title: "9"
+                    contentModel: VisualItemModel {
+                        Text {text: "Hello"}
+                        Text {text: "World"}
+                    }
+                }
+                Text {text: "World"}
+            }
+        }
+        AccordionItem{
+            title: "10"
+            contentModel: VisualItemModel {
+                Text {text: "Hello"}
+                AccordionItem{
+                    title: "11"
+                    contentModel: VisualItemModel {
+                        Text {text: "Hello"}
+                        AccordionItem{
+                            title: "12"
+                            contentModel: VisualItemModel {
+                                /*Table{
+                                    tableContent: ListModel {
+                                        ListElement {
+                                            value: ListElement {value: "A Masterpiece"; type: "field"; tooltip:"Hey" }
+                                            key: ListElement {value: "Gabriel"}
+                                            alphabet: ListElement { value: "soup" }
+                                        }
+                                        ListElement {
+                                            value: ListElement {value: "Brilliance"; type: "field"; placeholder: "lel"}
+                                            key: ListElement { value: "Jens" }
+                                            alphabet: ListElement { value: "order" }
+                                        }
+                                        ListElement {
+                                            value: ListElement {value: "Outstanding"; type: "field"}
+                                            key: ListElement { value: "Frederik" }
+                                            alphabet: ListElement { value: "yodels" }
+                                        }
+                                    }
+                                    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
+                                }*/
+                                Text {text: "Hello"}
+                            }
+                        }
+                    }
+                }
+                Text {text: "World"}
+            }
+        }
+    }
+}		

--- a/lib_qml/test.qml
+++ b/lib_qml/test.qml
@@ -82,26 +82,23 @@ Item {
                                                 AccordionItem{
                                                     title: "6"
                                                     contentModel: VisualItemModel {
-                                                        /*Table{
+                                                        Table{
                                                             tableContent: ListModel {
                                                                 ListElement {
-                                                                    value: ListElement {value: "A Masterpiece"; type: "field"; tooltip:"Hey" }
-                                                                    key: ListElement {value: "Gabriel"}
-                                                                    alphabet: ListElement { value: "soup" }
+                                                                    value: ListElement {value: [ListElement{value: "A Masterpiece"}] type: "field"; tooltip:"Hey" }
+                                                                    key: ListElement {value: [ListElement{value: "Gabriel"}]}
                                                                 }
                                                                 ListElement {
-                                                                    value: ListElement {value: "Brilliance"; type: "field"; placeholder: "lel"}
-                                                                    key: ListElement { value: "Jens" }
-                                                                    alphabet: ListElement { value: "order" }
+                                                                    value: ListElement {value: [ListElement{value: "Brilliance"}] type: "field"; placeholder: "lel"}
+                                                                    key: ListElement { value: [ListElement{value: "Jens"}] type: "field"}
                                                                 }
                                                                 ListElement {
-                                                                    value: ListElement {value: "Outstanding"; type: "field"}
-                                                                    key: ListElement { value: "Frederik" }
-                                                                    alphabet: ListElement { value: "yodels" }
+                                                                    value: ListElement {value: [ListElement{value: "Outstanding"}] type: "field"}
+                                                                    key: ListElement { value: [ListElement{value: "Frederik"},ListElement{value: "Jacob"},ListElement{value: "Markus"}] type: "combo" }
                                                                 }
                                                             }
-                                                            columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
-                                                        }*/
+                                                            columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"}]
+                                                        }
                                                         Text {text: "Hello"}
                                                     }
                                                 }
@@ -120,26 +117,23 @@ Item {
         AccordionItem{
             title: "7"
             contentModel: VisualItemModel {
-                /*Table{
+                Table{
                     tableContent: ListModel {
                         ListElement {
-                            value: ListElement {value: "A Masterpiece"; type: "field"; tooltip:"Hey" }
-                            key: ListElement {value: "Gabriel"}
-                            alphabet: ListElement { value: "soup" }
+                            value: ListElement {value: [ListElement{value: "A Masterpiece"}] type: "field"; tooltip:"Hey" }
+                            key: ListElement {value: [ListElement{value: "Gabriel"}]}
                         }
                         ListElement {
-                            value: ListElement {value: "Brilliance"; type: "field"; placeholder: "lel"}
-                            key: ListElement { value: "Jens" }
-                            alphabet: ListElement { value: "order" }
+                            value: ListElement {value: [ListElement{value: "Brilliance"}] type: "field"; placeholder: "lel"}
+                            key: ListElement { value: [ListElement{value: "Jens"}] type: "field"}
                         }
                         ListElement {
-                            value: ListElement {value: "Outstanding"; type: "field"}
-                            key: ListElement { value: "Frederik" }
-                            alphabet: ListElement { value: "yodels" }
+                            value: ListElement {value: [ListElement{value: "Outstanding"}] type: "field"}
+                            key: ListElement { value: [ListElement{value: "Frederik"},ListElement{value: "Jacob"},ListElement{value: "Markus"}] type: "combo" }
                         }
                     }
-                    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
-                }*/
+                    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"}]
+                }
                 Text {text: "Hello"}
 
             }


### PR DESCRIPTION
This pull includes a revamped UI for config navigation via QML generation. 

The rendering of the UI is dependent on two QML files, **AccordionItem.qml** and **Table.qml**. These files are found in _lib_qml_ and need to be moved into the directory that the qml files are generated in (by default, _/tmp/_)
